### PR TITLE
GPC Implementation

### DIFF
--- a/js/session.js
+++ b/js/session.js
@@ -14,6 +14,12 @@
       ) {
       Drupal.eu_cookie_compliance.declineAction();
     }
+    else if (
+      !navigator.globalPrivacyControl &&
+      localStorage.getItem('tmt_cookie_opt_out') !== '1'
+    ) {
+      Drupal.eu_cookie_compliance.acceptAction();
+    }
   });
 
 })(jQuery, Drupal)

--- a/js/session.js
+++ b/js/session.js
@@ -1,0 +1,19 @@
+/**
+ * @file session.js
+ *
+ * GPC Implementation.
+ */
+(function ($, Drupal) {
+  "use strict"
+
+  // Respect GPC signal from browser unless overridden by user.
+  $(function() {
+    if (
+      navigator.globalPrivacyControl &&
+      localStorage.getItem('tmt_cookie_opt_out') !== '0'
+      ) {
+      Drupal.eu_cookie_compliance.declineAction();
+    }
+  });
+
+})(jQuery, Drupal)

--- a/js/toggle.js
+++ b/js/toggle.js
@@ -89,9 +89,11 @@
       var handleToggle = function (event) {
         if (event.target.checked) {
           Drupal.eu_cookie_compliance.declineAction();
+          localStorage.setItem('tmt_cookie_opt_out', '1');
         }
         else {
           Drupal.eu_cookie_compliance.acceptAction();
+          localStorage.setItem('tmt_cookie_opt_out', '0');
         }
       };
 

--- a/js/toggle.js
+++ b/js/toggle.js
@@ -17,9 +17,18 @@
   var cookieCheckboxSelector = '.tmt-eu-cookie-compliance-toggle input[type="checkbox"]';
 
   // Borrowed from the top of eu_cookie_compliance/js/eu_cookie_compliance.js
-  var cookieValueDisagreed = (typeof drupalSettings.eu_cookie_compliance.cookie_value_disagreed === 'undefined' || drupalSettings.eu_cookie_compliance.cookie_value_disagreed === '') ? '0' : drupalSettings.eu_cookie_compliance.cookie_value_disagreed;
-  var cookieValueAgreedShowThankYou = (typeof drupalSettings.eu_cookie_compliance.cookie_value_agreed_show_thank_you === 'undefined' || drupalSettings.eu_cookie_compliance.cookie_value_agreed_show_thank_you === '') ? '1' : drupalSettings.eu_cookie_compliance.cookie_value_agreed_show_thank_you;
-  var cookieValueAgreed = (typeof drupalSettings.eu_cookie_compliance.cookie_value_agreed === 'undefined' || drupalSettings.eu_cookie_compliance.cookie_value_agreed === '') ? '2' : drupalSettings.eu_cookie_compliance.cookie_value_agreed;
+  var cookieValueDisagreed = (
+    typeof drupalSettings.eu_cookie_compliance.cookie_value_disagreed === 'undefined' ||
+    drupalSettings.eu_cookie_compliance.cookie_value_disagreed === ''
+  ) ? '0' : drupalSettings.eu_cookie_compliance.cookie_value_disagreed;
+  var cookieValueAgreedShowThankYou = (
+    typeof drupalSettings.eu_cookie_compliance.cookie_value_agreed_show_thank_you === 'undefined' ||
+    drupalSettings.eu_cookie_compliance.cookie_value_agreed_show_thank_you === ''
+  ) ? '1' : drupalSettings.eu_cookie_compliance.cookie_value_agreed_show_thank_you;
+  var cookieValueAgreed = (
+    typeof drupalSettings.eu_cookie_compliance.cookie_value_agreed === 'undefined' ||
+    drupalSettings.eu_cookie_compliance.cookie_value_agreed === ''
+  ) ? '2' : drupalSettings.eu_cookie_compliance.cookie_value_agreed;
 
   var statusIsAgreed = function (status) {
     if (status !== null) {
@@ -43,7 +52,9 @@
 
     $(cookieCheckboxSelector).prop('checked', !isAgreed);
 
-    $(window).trigger(isAgreed ? 'enableCookies' : 'disableCookies');
+    $(window).trigger(
+      isAgreed ? 'enableCookies' : 'disableCookies'
+    );
   };
 
   /**
@@ -59,7 +70,7 @@
       isAgreed: isAgreed,
     });
 
-    $(window).once('tmt-eu-cookie-compliance-handle-post-status-load').trigger(
+    $(window).trigger(
       isAgreed ? 'enableCookies' : 'disableCookies'
     );
   };
@@ -84,9 +95,18 @@
         }
       };
 
-      $(context)
-        .find(cookieCheckboxSelector)
-        .once('tmt-eu-cookie-compliance-toggle')
+      // Respect GPC signal from browser.
+      $(function() {
+        if (navigator.globalPrivacyControl) {
+          Drupal.eu_cookie_compliance.declineAction();
+          $(cookieCheckboxSelector).prop({
+            'checked': true,
+            'disabled': true
+          });
+        }
+      });
+
+      $(once('tmt-eu-cookie-compliance-toggle', cookieCheckboxSelector, context))
         .on('change', handleToggle)
         .each(function () {
           // Initial status.

--- a/js/toggle.js
+++ b/js/toggle.js
@@ -95,14 +95,14 @@
         }
       };
 
-      // Respect GPC signal from browser.
+      // Respect GPC signal from browser unless overridden by user.
       $(function() {
-        if (navigator.globalPrivacyControl) {
+        if (
+          navigator.globalPrivacyControl &&
+          localStorage.getItem('tmt_cookie_opt_out') !== '0'
+          ) {
           Drupal.eu_cookie_compliance.declineAction();
-          $(cookieCheckboxSelector).prop({
-            'checked': true,
-            'disabled': true
-          });
+          $(cookieCheckboxSelector).prop('checked', true);
         }
       });
 

--- a/tmt_eu_cookie_compliance.info.yml
+++ b/tmt_eu_cookie_compliance.info.yml
@@ -1,7 +1,7 @@
 name: TMT EU Cookie Compliance
 type: module
 description: Adds custom integration with EU Cookie Compliance
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 package: Two Men and a Truck
 
 dependencies:

--- a/tmt_eu_cookie_compliance.libraries.yml
+++ b/tmt_eu_cookie_compliance.libraries.yml
@@ -3,5 +3,11 @@ toggle:
     js/toggle.js: {}
   dependencies:
     - core/jquery
-    - core/jquery.once
+    - core/once
     - eu_cookie_compliance/eu_cookie_compliance
+
+session:
+  js:
+    js/session.js: {}
+  dependencies:
+    - core/jquery

--- a/tmt_eu_cookie_compliance.module
+++ b/tmt_eu_cookie_compliance.module
@@ -19,5 +19,5 @@ function tmt_eu_cookie_compliance_theme($existing, $type, $theme, $path) {
  */
 function tmt_eu_cookie_compliance_page_attachments_alter(array &$page) {
   // Attach the session management script on every page.
-  $page['#attached']['library'][] = 'tmt_tracking/session';
+  $page['#attached']['library'][] = 'tmt_eu_cookie_compliance/session';
 }

--- a/tmt_eu_cookie_compliance.module
+++ b/tmt_eu_cookie_compliance.module
@@ -13,3 +13,11 @@ function tmt_eu_cookie_compliance_theme($existing, $type, $theme, $path) {
     ],
   ];
 }
+
+/**
+ * Implements hook_page_attachments_alter().
+ */
+function tmt_eu_cookie_compliance_page_attachments_alter(array &$page) {
+  // Attach the session management script on every page.
+  $page['#attached']['library'][] = 'tmt_tracking/session';
+}


### PR DESCRIPTION
- Fix once() deprecations to resolve Drupal 10+ JS errors.
- Enforce browser GPC signal when cookie consent block is loaded.